### PR TITLE
Fix: Add configurable and sanitized attachment folder suffix with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Following parameters can be adapted using `alfresco-global.properties` file or J
 extract.attachments.mimetype.list=message/rfc822,application/vnd.ms-outlook
 # SAME, SEPARATE
 imap.attachments.mode=SEPARATE
+# Folder's suffix in SEPARATE mode
+# Fallback to -attachments if null or couldn't be read
+imap.attachments.folder.suffix=-attachment
 ```
 
 ## Building

--- a/src/main/resources/alfresco/module/alfresco-outlook-attachments/context/service-context.xml
+++ b/src/main/resources/alfresco/module/alfresco-outlook-attachments/context/service-context.xml
@@ -26,6 +26,7 @@
         <property name="serviceRegistry" ref="ServiceRegistry"/>
         <property name="attachmentsExtractorMode" value="${imap.attachments.mode}"/>
         <property name="mimetypeService" ref="mimetypeService"/>
+        <property name="attachmentsFolderSuffix" value="${imap.attachments.folder.suffix}" />
     </bean>
 
     <bean id="${project.artifactId}_outlookAttachmentsBehaviour" class="org.alfresco.behaviour.ExtractOutlookAttachments" init-method="init">


### PR DESCRIPTION
Fixes #1

## Problem

The original code used a hardcoded suffix (`"-attachments"`) for attachment folders without external configuration support or error handling. This caused:
- No ability to customize attachment folder names
- No fallback mechanism if `${imap.attachments.folder.suffix}` property was misconfigured
- Unpredictable behavior with empty values or special characters

## Solution

### 1. Added sanitization and fallback methods

```java
// New method to clean the suffix
private String sanitizeSuffix(String raw)

// New method to get a valid suffix with fallback
private String getEffectiveFolderSuffix()
```

#### Features:
- Removes dangerous characters (/, \, NULL)
- Handles multiple spaces
- Removes unnecessary quotes
- Automatic fallback to "-attachments" if suffix is invalid

### 2. Spring dependency injection

```java
// New configurable property
private String attachmentsFolderSuffix;

public void setAttachmentsFolderSuffix(String suffix)
```

#### XML Configuration:

```xml
<property name="attachmentsFolderSuffix" value="${imap.attachments.folder.suffix}" />
```

### 3. Secure usage in `extractAttachments()`

```java
// BEFORE
attachmentsFolderName = messageName + "-attachments";

// AFTER
String effective = getEffectiveFolderSuffix();
attachmentsFolderName = messageName + effective;
```

## Changes

Modified files

- src/main/java/org/alfresco/mail/AttachmentsExtractor.java
    - Added DEFAULT_ATTACHMENTS_SUFFIX constant
    - Added attachmentsFolderSuffix attribute
    - Added sanitizeSuffix() method
    - Added getEffectiveFolderSuffix() method
    - Added setAttachmentsFolderSuffix() setter
    - Modified folder name creation in extractAttachments()

- src/main/resources/alfresco/module/.../context/service-context.xml
    - Added attachmentsFolderSuffix property injection
